### PR TITLE
encoding, new marshal interface

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -31,14 +31,6 @@ type Primitive struct {
 	context   Key
 }
 
-// DEPRECATED!
-//
-// Use MetaData.PrimitiveDecode instead.
-func PrimitiveDecode(primValue Primitive, v interface{}) error {
-	md := MetaData{decoded: make(map[string]bool)}
-	return md.unify(primValue.undecoded, rvalue(v))
-}
-
 // PrimitiveDecode is just like the other `Decode*` functions, except it
 // decodes a confl value that has already been parsed. Valid primitive values
 // can *only* be obtained from values filled by the decoder functions,
@@ -54,6 +46,28 @@ func (md *MetaData) PrimitiveDecode(primValue Primitive, v interface{}) error {
 	md.context = primValue.context
 	defer func() { md.context = nil }()
 	return md.unify(primValue.undecoded, rvalue(v))
+}
+
+type Decoder struct {
+	reader io.Reader
+}
+
+func NewDecoder(r io.Reader) *Decoder {
+	return &Decoder{r}
+}
+
+func (dec *Decoder) Decode(v interface{}) error {
+	bs, err := ioutil.ReadAll(dec.reader)
+	if err != nil {
+		return err
+	}
+	_, err = Decode(string(bs), v)
+	return err
+}
+
+func Unmarshal(bs []byte, v interface{}) error {
+	_, err := Decode(string(bs), v)
+	return err
 }
 
 // Decode will decode the contents of `data` in confl format into a pointer

--- a/decode_meta.go
+++ b/decode_meta.go
@@ -66,6 +66,15 @@ func (k Key) add(piece string) Key {
 	return newKey
 }
 
+func (k Key) insert(piece string) Key {
+	newKey := make(Key, len(k), len(k)+1)
+	copy(newKey, k)
+	insertedKey := make(Key, 1)
+	insertedKey[0] = piece
+	newKey = append(insertedKey, newKey...)
+	return newKey
+}
+
 // Keys returns a slice of every key in the data, including key groups.
 // Each key is itself a slice, where the first element is the top of the
 // hierarchy and the last is the most specific.

--- a/decode_test.go
+++ b/decode_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -92,6 +93,29 @@ my {
 	if !reflect.DeepEqual(simple, answer) {
 		t.Fatalf("Expected\n-----\n%#v\n-----\nbut got\n-----\n%#v\n",
 			answer, simple)
+	}
+
+	// Now Try decoding using Decoder
+	var simpleDec simpleType
+	decoder := NewDecoder(strings.NewReader(simpleConfigString))
+	err = decoder.Decode(&simpleDec)
+	assert.Tf(t, err == nil, "err nil?%v", err)
+
+	assert.Tf(t, simpleDec.AgePtr == nil, "must have nil ptr")
+	if !reflect.DeepEqual(simpleDec, answer) {
+		t.Fatalf("Expected\n-----\n%#v\n-----\nbut got\n-----\n%#v\n",
+			answer, simpleDec)
+	}
+
+	// Now Try decoding using Unmarshal
+	var simple2 simpleType
+	err = Unmarshal([]byte(simpleConfigString), &simple2)
+	assert.Tf(t, err == nil, "err nil?%v", err)
+
+	assert.Tf(t, simple2.AgePtr == nil, "must have nil ptr")
+	if !reflect.DeepEqual(simple2, answer) {
+		t.Fatalf("Expected\n-----\n%#v\n-----\nbut got\n-----\n%#v\n",
+			answer, simple2)
 	}
 }
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -146,10 +146,10 @@ albums [
 	    songs [
 	      { name = "Jungleland" },
 	      { name = "Meeting Across the River" }
-	    ]
-    }
-    {
-    	name = "Born in the USA"
+		]
+	}
+	{
+		name = "Born in the USA"
   	    songs [
 	      { name = "Glory Days" },
 	      { name = "Dancing in the Dark" }


### PR DESCRIPTION
- Implement `Marshal` , `Unmarshal` and `Decoder/Encoder` interfaces refs #1 
- tests had never been converted from toml for encoding, so fixed those.
