### PR TITLE
Make MultiLine comments more friendly, strip trailing ), strip starting indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ This is a config parser most similar to Nginx, supports
 Json format, but with line-breaks, comments, etc.   Also, like
 Nginx is more lenient.
 
-[![GoDoc](https://godoc.org/github.com/lytics/confl?status.svg)](https://godoc.org/github.com/lytics/confl).    
+Uses same syntax as https://github.com/vstakhov/libucl
 
-Use [SubmlimeText Nginx Plugin](https://github.com/brandonwamboldt/sublime-nginx)
+[![GoDoc](https://godoc.org/github.com/lytics/confl?status.svg)](https://godoc.org/github.com/lytics/confl).
+
+Use [SubmlimeText Nginx Plugin](https://github.com/brandonwamboldt/sublime-nginx) for formatting.
 
 Credit to [BurntSushi/Toml](https://github.com/BurntSushi/toml) and [Apcera/Gnatsd](https://github.com/apcera/gnatsd/tree/master/conf) from which 
 this was derived.
@@ -18,9 +20,12 @@ this was derived.
 
 # support the name = value format
 title = "conf Example"
-
+# support json semicolon
+title2 : "conf example2"
+# support omitting = or : because key starts a line
+title3 "conf example"
 # note, we do not have to have quotes
-title2 = Without Quotes
+title4 = Without Quotes
 
 # for Sections we can use brackets
 hand {
@@ -39,16 +44,16 @@ address : {
   "country" : "Westeros"
 }
 
-# sections can omit the colon before bracket or leave in 
+# sections can omit the colon, equal before bracket 
 seenwith {
   # nested section
   # can be spaces or tabs for nesting
-  jaime {
+  jaime : {
     season = season1
     episode = "episode1"
   }
 
-  cersei {
+  cersei = {
     season = season1
     episode = "episode1"
   }
@@ -66,7 +71,7 @@ seasons = [
 ]
 
 
-# long fields can use parens to do multi-line
+# long strings can use parens to allow multi-line
 description (
     we possibly
     can have

--- a/_examples/example.go
+++ b/_examples/example.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/araddon/gou"
+
 	"github.com/lytics/confl"
 )
 
@@ -45,6 +47,9 @@ type character struct {
 }
 
 func main() {
+	gou.SetupLogging("debug")
+	gou.SetColorOutput()
+
 	var config Config
 	if _, err := confl.DecodeFile("example.conf", &config); err != nil {
 		fmt.Println(err)

--- a/lex_test.go
+++ b/lex_test.go
@@ -28,7 +28,7 @@ func expect(t *testing.T, lx *lexer, items []item) {
 					u.Warnf("mismatch at position: %v   %q!=%q", pos, string(r), string(got[pos]))
 					break
 				} else {
-					u.Debugf("match at position: %v   %q=%q", pos, string(r), string(got[pos]))
+					//u.Debugf("match at position: %v   %q=%q", pos, string(r), string(got[pos]))
 				}
 			}
 			t.Fatalf("Testing: '%s'\nExpected %q, received %q\n",

--- a/parse.go
+++ b/parse.go
@@ -284,23 +284,24 @@ func maybeRemoveIndents(s string) string {
 		return s
 	}
 	lines := strings.Split(s, "\n")
+	indent := 0
+findIndent:
+	for idx, r := range lines[0] {
+		switch r {
+		case '\t', ' ':
+			// keep consuming
+		default:
+			// first non-whitespace we are going to break
+			// and use this as indent size.   This makes a variety of assumptions
+			// - subsequent indents use same mixture of spaces/tabs
+			indent = idx
+			break findIndent
+		}
+	}
+
 	for i, line := range lines {
 		//u.Debugf("%v indent=%d line %q", i, indent, line)
-	findIndent:
-		for idx, r := range line {
-			switch r {
-			case '\t', ' ':
-				// keep consuming
-			default:
-				// first non-whitespace we are going to break
-				// and use this as indent size
-				if idx > 0 {
-					//u.Debugf("chooping line: %q", line[0:idx-1])
-					lines[i] = line[idx:]
-				}
-				break findIndent
-			}
-		}
+		lines[i] = line[indent:]
 	}
 	return strings.Join(lines, "\n")
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -54,22 +54,6 @@ func TestParseSample1(t *testing.T) {
 	test(t, sample1, ex)
 }
 
-var tomlHeaderSample = `
-[foo]
-ip   = '127.0.0.1'
-
-`
-
-// NOT CURRENTLY A FEATURE
-// func TestParseTomlHeader(t *testing.T) {
-// 	ex := map[string]interface{}{
-// 		"foo": map[string]interface{}{
-// 			"ip": "127.0.0.1",
-// 		},
-// 	}
-// 	test(t, tomlHeaderSample, ex)
-// }
-
 var cluster = `
 cluster {
   port: 4244
@@ -117,14 +101,19 @@ foo  {
   expr = '(true == "false")'
   text = 'This is a multi-line
 text block.'
+  text2 (
+    hello world
+    this is multi line
+)
 }
 `
 
 func TestParseSample3(t *testing.T) {
 	ex := map[string]interface{}{
 		"foo": map[string]interface{}{
-			"expr": "(true == \"false\")",
-			"text": "This is a multi-line\ntext block.",
+			"expr":  "(true == \"false\")",
+			"text":  "This is a multi-line\ntext block.",
+			"text2": "hello world\nthis is multi line",
 		},
 	}
 	test(t, sample3, ex)

--- a/parse_test.go
+++ b/parse_test.go
@@ -103,7 +103,7 @@ foo  {
 text block.'
   text2 (
     hello world
-    this is multi line
+      this is multi line
 )
 }
 `
@@ -113,7 +113,7 @@ func TestParseSample3(t *testing.T) {
 		"foo": map[string]interface{}{
 			"expr":  "(true == \"false\")",
 			"text":  "This is a multi-line\ntext block.",
-			"text2": "hello world\nthis is multi line",
+			"text2": "hello world\n  this is multi line",
 		},
 	}
 	test(t, sample3, ex)


### PR DESCRIPTION
- Strip first newline for ( based multi-line comments
- try to remove the initial indent closes #3 
- remove trailing ) that is included if EOF multi-line comment closes #2 
