### PR TITLE
Bad input would cause an infinite loop

### DIFF
--- a/lex_test.go
+++ b/lex_test.go
@@ -37,6 +37,14 @@ func expect(t *testing.T, lx *lexer, items []item) {
 	}
 }
 
+func TestLexBadConfString(t *testing.T) {
+	lx := lex("\x0e9\xbd\xbf\xefr")
+	item := lx.nextItem()
+	if item.typ != itemError {
+		t.Fatal(item.val)
+	}
+}
+
 func TestLexSimpleKeyStringValues(t *testing.T) {
 	expectedItems := []item{
 		{itemKey, "foo", 1},


### PR DESCRIPTION
closes #6 bad input (invalid characters in keys) would cause infinite loop
- sanitize key inputs looking for valid characters
- look for eof unexepectedly
